### PR TITLE
Remove reference to deprecate notNull in docs

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -371,7 +371,6 @@ const ValidateMe = sequelize.define('foo', {
       isDecimal: true,          // checks for any numbers
       isLowercase: true,        // checks for lowercase
       isUppercase: true,        // checks for uppercase
-      notNull: true,            // won't allow null
       isNull: true,             // only allows null
       notEmpty: true,           // don't allow empty strings
       equals: 'specific value', // only allow a specific value


### PR DESCRIPTION
Deprecated here: https://github.com/sequelize/sequelize/blob/0dad57f7927d23fe32d74d022824eb4b62315ca6/lib/utils/validator-extras.js#L81
